### PR TITLE
Replace reference to deprecated exception class

### DIFF
--- a/CRM/Managegroup/Check.php
+++ b/CRM/Managegroup/Check.php
@@ -17,7 +17,7 @@ class CRM_Managegroup_Check {
    *
    * @param array $messages
    *
-   * @throws \API_Exception
+   * @throws \CRM_Core_Exception
    * @throws \Civi\API\Exception\UnauthorizedException
    */
   public function __construct($messages) {
@@ -26,8 +26,8 @@ class CRM_Managegroup_Check {
 
   /**
    * @return array
-   * @throws \API_Exception
-   * @throws \CiviCRM_API3_Exception
+   * @throws \CRM_Core_Exception
+   * @throws \CRM_Core_Exception
    * @throws \Civi\API\Exception\UnauthorizedException
    */
   public function checkRequirements() {
@@ -39,8 +39,8 @@ class CRM_Managegroup_Check {
   /**
    * Check Group is set to inactive or disable.
    *
-   * @throws \API_Exception
-   * @throws \CiviCRM_API3_Exception
+   * @throws \CRM_Core_Exception
+   * @throws \CRM_Core_Exception
    * @throws \Civi\API\Exception\UnauthorizedException
    */
   private function checkIfGroupisSetToInactive() {

--- a/api/v3/Job/Groupaction.php
+++ b/api/v3/Job/Groupaction.php
@@ -22,7 +22,7 @@ function _civicrm_api3_job_Groupaction_spec(&$spec) {
  *
  * @see civicrm_api3_create_success
  *
- * @throws API_Exception
+ * @throws CRM_Core_Exception
  */
 function civicrm_api3_job_Groupaction($params) {
   // Fetch Active Group with date set for to mark inactive.
@@ -48,7 +48,7 @@ function civicrm_api3_job_Groupaction($params) {
             ]);
             $disableGroups[] = $group['title'] . ' ( ' . $group['id'] . ') ';
           }
-          catch (CiviCRM_API3_Exception $e) {
+          catch (CRM_Core_Exception $e) {
 
           }
         }


### PR DESCRIPTION
The api-specific exception classes have been deprecated and will soon be removed from core.
They are identical to CRM_Core_Exception.